### PR TITLE
feat: Add notHasProperty expectation

### DIFF
--- a/lib/expectations.js
+++ b/lib/expectations.js
@@ -13,6 +13,7 @@ module.exports = {
   contentType: expectContentType,
   statusCode: expectStatusCode,
   hasProperty: expectHasProperty,
+  notHasProperty: expectNotHasProperty,
   equals: expectEquals
 };
 
@@ -106,6 +107,31 @@ function expectHasProperty(expectation, body, req, res, userContext) {
       return result;
     } else {
       result.got = `response body has no ${expectedProperty} property`;
+      return result;
+    }
+  } else {
+    result.got = `response body is not an object`;
+    return result;
+  }
+}
+
+function expectNotHasProperty(expectation, body, req, res, userContext) {
+  debug('check notHasProperty');
+
+  const expectedProperty = template(expectation.notHasProperty, userContext);
+  let result = {
+    ok: false,
+    expected: expectedProperty,
+    type: 'notHasProperty'
+  };
+
+  if (typeof body === 'object') {
+    if (!_.has(body, expectedProperty)) {
+      result.ok = true;
+      result.got = expectedProperty;
+      return result;
+    } else {
+      result.got = `response body has ${expectedProperty} property`;
       return result;
     }
   } else {


### PR DESCRIPTION
###What
Makes it possible to assert that a property does not exist in the body of the response.

###Why
This is a change I made locally when running artillery against a graphql endpoint. Graphql will as a rule respond with a 200 even if some part of the query fails. Errors are contained in an errors array within the json response.

Here's an example failure:
```
{
  "data": null,
  "errors": [
    {
      "message": "Field 'repository' is missing required arguments: name",
      "path": [
        "query",
        "repository"
      ]
    }
}
```

If the request succeeds the response will also be a 200 but `data:` will contain an object and `errors:` will not exist. It's not possible to detect this with the existing expectations so I added a new one. 