### PR TITLE
Use debugger in stead of console.log

### DIFF
--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -14,35 +14,35 @@ module.exports = {
 };
 
 function prettyPrint(requestExpectations, req, res, userContext) {
-  console.log(
+  debug(
     chalk.blue('*', req.method, urlparse(req.url).path),
     req.name ? '- ' + req.name : ''
   );
 
   requestExpectations.results.forEach(result => {
-    console.log(
+    debug(
       `  ${result.ok ? chalk.green('ok') : chalk.red('not ok')} ${
         result.type
       } ${result.got} `
     );
 
     if (!result.ok) {
-      console.log('  expected:', result.expected);
-      console.log('       got:', result.got);
+      debug('  expected:', result.expected);
+      debug('       got:', result.got);
 
-      console.log(chalk.yellow('  Request params:'));
-      console.log(prepend(req.url, '    '));
-      console.log(prepend(JSON.stringify(req.json || '', null, 2), '    '));
-      console.log(chalk.yellow('  Headers:'));
+      debug(chalk.yellow('  Request params:'));
+      debug(prepend(req.url, '    '));
+      debug(prepend(JSON.stringify(req.json || '', null, 2), '    '));
+      debug(chalk.yellow('  Headers:'));
       Object.keys(res.headers).forEach(function(h) {
-        console.log('  ', h, ':', res.headers[h]);
+        debug('  ', h, ':', res.headers[h]);
       });
-      console.log(chalk.yellow('  Body:'));
-      console.log(prepend(String(JSON.stringify(res.body, null, 2)), '    '));
+      debug(chalk.yellow('  Body:'));
+      debug(prepend(String(JSON.stringify(res.body, null, 2)), '    '));
 
-      console.log(chalk.yellow('  User variables:'));
+      debug(chalk.yellow('  User variables:'));
       Object.keys(userContext.vars).filter(varName => varName !== '$processEnvironment').forEach(function(varName) {
-        console.log('    ', varName, ':', userContext.vars[varName]);
+        debug('    ', varName, ':', userContext.vars[varName]);
       });
     } else {
     }
@@ -50,7 +50,7 @@ function prettyPrint(requestExpectations, req, res, userContext) {
 }
 
 function jsonPrint(requestExpectations, req, res, userContext) {
-  console.log(JSON.stringify(requestExpectations));
+  debug(JSON.stringify(requestExpectations));
 }
 
 function prepend(text, str) {


### PR DESCRIPTION
This commit removes the direct use of console.log so it is possible to control the
output from this plugin.