### PR TITLE
Fix/content type expectation

### DIFF
--- a/lib/expectations.js
+++ b/lib/expectations.js
@@ -97,7 +97,7 @@ function expectHeaderEquals(expectation, body, req, res, userContext) {
 function expectContentType(expectation, body, req, res, userContext) {
   debug('check contentType');
   debug('expectation:', expectation);
-  debug('body:', body === null ? body : typeof body);
+  debug('body:', body === null ? 'null' : typeof body);
 
   const expectedContentType = template(expectation.contentType, userContext);
   let result = {

--- a/lib/expectations.js
+++ b/lib/expectations.js
@@ -97,7 +97,7 @@ function expectHeaderEquals(expectation, body, req, res, userContext) {
 function expectContentType(expectation, body, req, res, userContext) {
   debug('check contentType');
   debug('expectation:', expectation);
-  debug('body:', typeof body);
+  debug('body:', body === null ? body : typeof body);
 
   const expectedContentType = template(expectation.contentType, userContext);
   let result = {
@@ -108,6 +108,7 @@ function expectContentType(expectation, body, req, res, userContext) {
 
   if (expectedContentType === 'json') {
     if (
+      body !== null && 
       typeof body === 'object' &&
       res.headers['content-type'].indexOf('application/json') !== -1
     ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artillery-plugin-expect",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Expectations and assertions for HTTP",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -126,6 +126,37 @@ test('Expectation: notHasProperty', t => {
   });
 });
 
+test('Expectation: contentType', async (t) => {
+  const expectations = require('../lib/expectations');
+
+  const data = [
+    // expectation - body received - res.headers.content-type - user context - expected result
+    [ '{{ expectedContentType }}', {}, 'application/json', { expectedContentType: 'json' }, true ],
+    [ 'json', {}, 'application/json; charset=utf-8', {}, true ],
+    [ 'json', {}, 'charset=utf-8; application/json', {}, true ],
+    [ 'text/plain', 'string', 'text/plain', {}, true ],
+    [ 'TEXT/PLAIN', 'string', 'text/plain', {}, true ],
+    [ 'text/plain', 'string', 'TEXT/PLAIN', {}, true ],
+    [ 'text/plain', {}, 'text/plain', {}, true ],
+
+    [ 'text/plain', 'string', 'application/json', {}, false ],
+    [ 'json', null, 'application/json', {}, false ],
+    [ 'json', 'string', 'application/json', {}, false ],
+  ];
+
+  data.forEach((e) => {
+    const result = expectations.contentType(
+      { contentType: e[0] }, // expectation
+      e[1], // body
+      {}, // req
+      { headers: { 'content-type': e[2] }}, // res
+      { vars: e[3] } // userContext
+    );
+
+    t.true(result.ok === e[4]);
+  });
+});
+
 test('Integration with Artillery', async (t) => {
   shelljs.env["ARTILLERY_PLUGIN_PATH"] = path.resolve(__dirname, '..', '..');
   shelljs.env["PATH"] = process.env.PATH;


### PR DESCRIPTION
I'd like to add support to `application/problem+json` to be treated the same way of `application/json`. But I'd noticed that content-type expectation didn't have test cases, so before I make some changes I decided to add tests to it.

There was a subtle behaviour regarding `typeof null === object` which results [in a case](https://github.com/elton-okawa/artillery-plugin-expect/blob/9a5b48676009997e322777d69b75dad99d1ff772/lib/expectations.js#L119) that was never reached. It didn't cause any harm because it only changes the error message.

More info: [MDN typeof null](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#typeof_null)